### PR TITLE
drop offending toml syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,18 +11,3 @@ addopts = ["--cov-report=term-missing"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]
-
-[tool.tox]
-requires = ["tox>=4"]
-skip_missing_interpreters = true
-#env_list = ["3.8", "3.9", "3.10"]
-env_list = ["3.8"]
-
-[tool.tox.env_run_base]
-description = "run unit tests"
-deps = [
-    "pytest>=8",
-    "pytest-sugar",
-    "pytest-cov",
-]
-commands = [["pytest", "tests", "--cov={envsitepackagesdir}/ouroboros", "--cov-report=term-missing", { replace = "posargs", default = ["-vv"], extend = true }]]


### PR DESCRIPTION
@GoldenZephyr probably should have realized this before, but was trying to use the gt loop-closures in ros1 and realized that the tox section meant I couldn't actually do `pip3 install --user .` for ouroboros (it looks like the system version of setuptools on 20.04 doesn't support the full toml syntax or something) 