### PR TITLE
get rid of unused header to avoid confusion

### DIFF
--- a/extra/ouroboros_msgs/msg/SparkImageMsg.msg
+++ b/extra/ouroboros_msgs/msg/SparkImageMsg.msg
@@ -1,3 +1,2 @@
-std_msgs/Header header
 sensor_msgs/Image rgb
 sensor_msgs/Image depth

--- a/extra/ouroboros_msgs/msg/VlcImageMsg.msg
+++ b/extra/ouroboros_msgs/msg/VlcImageMsg.msg
@@ -1,4 +1,3 @@
-std_msgs/Header header
 ouroboros_msgs/VlcImageMetadataMsg metadata
 ouroboros_msgs/SparkImageMsg image
 float32[] embedding

--- a/extra/ouroboros_ros/src/ouroboros_ros/conversions.py
+++ b/extra/ouroboros_ros/src/ouroboros_ros/conversions.py
@@ -48,7 +48,6 @@ def vlc_image_to_msg(
     vlc_msg = VlcImageMsg()
     if vlc.image is not None and convert_image:
         vlc_msg.image = spark_image_to_msg(vlc.image)
-    vlc_msg.header = vlc_msg.image.header
     vlc_msg.metadata = vlc_image_metadata_to_msg(vlc.metadata)
     if vlc.embedding is not None and convert_embedding:
         vlc_msg.embedding = vlc.embedding.tolist()

--- a/extra/ouroboros_ros/src/ouroboros_ros/vlc_multirobot_server_ros.py
+++ b/extra/ouroboros_ros/src/ouroboros_ros/vlc_multirobot_server_ros.py
@@ -184,7 +184,7 @@ class VlcMultirobotServerRos(VlcServerRos):
     def client_embedding_callback(self, vlc_img_msg, robot_id):
         # Add image
         vlc_image = vlc_image_from_msg(vlc_img_msg)
-        vlc_stamp = vlc_img_msg.header.stamp.to_nsec()
+        vlc_stamp = vlc_img_msg.metadata.epoch_ns
         new_uuid = self.vlc_server.add_embedding_no_image(
             self.robot_infos[robot_id].session_id,
             vlc_image.embedding,


### PR DESCRIPTION
pull out unnecessary header so that timestamp is only in metadata to avoid confusion (and fixes multi-robot bug)